### PR TITLE
Fix bug where traffic lights were in the centre

### DIFF
--- a/parts/toolbar-navbar.css
+++ b/parts/toolbar-navbar.css
@@ -22,6 +22,7 @@
 .titlebar-buttonbox-container {
     position: fixed;
     top: 0;
+    left: 0;
     height: var(--nav-bar-height);
 }
 


### PR DESCRIPTION
![CleanShot 2024-10-25 at 08 31 41@2x](https://github.com/user-attachments/assets/a451afbe-d058-43ae-9a2c-de80f318a2c8)
Bug sans the changes. ^

There is also an issue where people using config.devPixelsPerPx have the titlebars uncentered, no way around that except manually changing the translateY for the container.